### PR TITLE
🚀 Auto-update rxiv-maker to v1.5.10

### DIFF
--- a/Formula/rxiv-maker.rb
+++ b/Formula/rxiv-maker.rb
@@ -1,8 +1,8 @@
 class RxivMaker < Formula
   desc "Automated LaTeX article generation with modern CLI and figure creation"
   homepage "https://github.com/HenriquesLab/rxiv-maker"
-  url "https://github.com/HenriquesLab/rxiv-maker/archive/refs/tags/v1.5.8.tar.gz"
-  sha256 "6b1d042ed63285f4f8c6995f36acbd2debeed4cfe9c0a090d2adb7ef3e3a8cdf"
+  url "https://github.com/HenriquesLab/rxiv-maker/archive/refs/tags/v1.5.10.tar.gz"
+  sha256 "a9be751bf36fb2a6b4b7523146e4949d54d19f6a755d17439cee55f07ec0a74b"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
## 📦 Automatic Formula Update

This PR updates the rxiv-maker Homebrew formula to version **v1.5.10**.

### 🔄 Changes Made
- ✅ Updated release URL to: `https://github.com/HenriquesLab/rxiv-maker/archive/refs/tags/v1.5.10.tar.gz`
- ✅ Updated SHA256 hash to: `a9be751bf36fb2a6b4b7523146e4949d54d19f6a755d17439cee55f07ec0a74b`

### 🧪 Testing
After merging, the formula can be tested with:
```bash
brew tap HenriquesLab/rxiv-maker
brew install rxiv-maker
rxiv --version
```

### 🤖 Automation
This PR was manually created after the automated workflow failed due to PyPI timing issues. The automated workflow triggered immediately after the v1.5.10 release but PyPI files were not yet available via API.

**Release**: https://github.com/HenriquesLab/rxiv-maker/releases/tag/v1.5.10
**Original Workflow**: https://github.com/HenriquesLab/rxiv-maker/actions/runs/16996638890